### PR TITLE
Update transform_master_test.go

### DIFF
--- a/pkg/ddc/jindo/transform_master_test.go
+++ b/pkg/ddc/jindo/transform_master_test.go
@@ -1,4 +1,5 @@
 /*
+Copyright 2022 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Ⅰ. Standardized the license of pkg/ddc/jindo/transform_master_test.go
